### PR TITLE
Updated to Android 27, Kotlin 1.1.51, and android-maven-gradle 2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,15 +3,14 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
 
     defaultConfig {
         applicationId "xyz.matteobattilana.weatherview"
         minSdkVersion 16
-        targetSdkVersion 26
-        versionCode 6
-        versionName "2.0.0"
+        targetSdkVersion 27
+        versionCode 7
+        versionName "2.0.1"
         vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
@@ -28,7 +27,7 @@ android {
 
 dependencies {
     implementation "com.android.support:appcompat-v7:$support_library_version"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.0-beta1'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     implementation "org.jetbrains.anko:anko-commons:$anko_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.support_library_version = '26.0.1'
-    ext.kotlin_version = '1.1.3-2'
+    ext.support_library_version = '27.0.0'
+    ext.kotlin_version = '1.1.51'
     ext.anko_version = '0.10.1'
 
     repositories {
@@ -11,9 +11,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,6 +25,7 @@ android {
 
 group = 'com.github.MatteoBattilana'
 version = android.defaultConfig.versionName
+project.archivesBaseName = 'WeatherView'
 
 dependencies {
     implementation "com.android.support:support-annotations:$support_library_version"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,14 +3,13 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
-        versionCode 3
-        versionName "2.0.1"
+        targetSdkVersion 27
+        versionCode 4
+        versionName "2.0.2"
     }
     buildTypes {
         release {


### PR DESCRIPTION
Closes #14 

Due to an incompatibility between android-maven-gradle-plugin 1.5 and Android Gradle plugin 3.0.0, dependencies were not included in the generated `pom.xml` and therefore not included in the final application `.dex`.